### PR TITLE
Handle IRC /me actions

### DIFF
--- a/discord.go
+++ b/discord.go
@@ -92,8 +92,10 @@ func isValidDiscordNick(nick string) bool {
 }
 
 func convertIRCMessageToDiscord(user *ircConn, ircMessage string) (discordMessage string) {
+	actionRegex := regexp.MustCompile(`^\x01ACTION (.*)\x01$`)
 	discordMessage = ircMessage
 	discordMessage = strings.TrimSpace(discordMessage)
+	discordMessage = actionRegex.ReplaceAllString(discordMessage, `*$1*`)
 	discordMessage = convertIRCMentionsToDiscord(user, discordMessage)
 	return discordMessage
 }


### PR DESCRIPTION
When using the common `/me does thing` command on many IRC clients, it's sent to Discord as literal `\x01ACTION does thing\x01`.
This fixes the issue by converting the message to italics.