### PR TITLE
Alter handling of animated emoji

### DIFF
--- a/irc.go
+++ b/irc.go
@@ -137,7 +137,7 @@ func convertDiscordContentToIRC(text string, c *ircConn) (content string) {
 	})
 
 	content = patternEmoji.ReplaceAllStringFunc(content, func(match string) string {
-		return fmt.Sprintf("\x0305:%s:\x03", strings.Split(match[2:len(match)-1], ":")[0])
+		return fmt.Sprintf("\x0305:%s:\x03", match[strings.Index(match, ":") + 1 : strings.LastIndex(match, ":")])
 	})
 
 	// content = patternBold.ReplaceAllStringFunc(content, func(match string) string {


### PR DESCRIPTION
This PR fixes #3.
1be17f1ae951374968232393a1c492622b874178 allowed patternEmoji to capture `<a:b1nzy:392938283556143104>` format emojis, but the replacement function was not correctly updated.

For animated emoji, strings.Split operates on the slice `:b1nzy:392938283556143104` - it includes the preceding colon (whereas the slice for non-animated emoji does not); as a result, strings.Split[0] is the empty string, instead of the emoji name.

This PR fixes the issue by instead slicing match on the first and last colons (non-inclusive).